### PR TITLE
Organize the section on writing systems

### DIFF
--- a/english/playbook.md
+++ b/english/playbook.md
@@ -880,25 +880,50 @@ We’re mentioning spoken and written languages here for a few reasons:
 * Written text means script, and written data conservation means proper encoding. Historically, this has been a delicate issue for localization, but today, thanks to the Unicode Standard, it has become much easier to handle and preserve text strings.
 * Each form, spoken or written, has its specificities: permanency for written language, versus immediacy for spoken language; complexity and intricacy for written language, versus simplicity and tonality for spoken language. Of course, scripted or recorded speech can more closely resemble written language, from the perspective of complexity, or grammatical usage.
 
-Written languages can be classified in two main groups based on their writing systems, with one group for the languages and scripts that represent consonants and vowels (aka alphabets) and one for those that represent syllables (aka syllabaries).
+Writing systems can be classified into a few major groups:
+- true alphabets, which represent consonants and vowels
+- abjads, which represent mostly only consonants
+- abugidas or syllabaries, which represent syllables
+- ideographics
 
-Among the alphabetic scripts, we can include:
+##### Alphabets
+In true alphabets, characters represents consonants and vowels.
+* Greek
+* Latin
+* Armenian
+* Georgian
+* Cyrillic
+* Hiragana and Katakana
+* Hangul, used for Korean
+* N’Ko, Tifinagh etc.
 
-* Arabic, Farsi (Persian), Hebrew, and Urdu, all being written right-to-left, all being also considered consonants-based (aka Abjads).
-* All languages based on the Latin script/alphabet, in its extended form, with diacritics, which today include most Western and Central European languages (some might also use the Cyrillic or Arabic script), as well as languages like Vietnamese or African languages for which written scripts were developed by European missionaries, like Zulu.
-* All languages based on the Cyrillic alphabet.
-* Greek.
-* The Hiragana and Katakana scripts used in Japanese, often for borrowed words.
-* Korean (Hangul).
-* Armenian, Gaelic, Georgian, Mongolian, N’Ko, Tifinagh, etc.
+The Latin alphabet - the one you're reading right now! - is notable for its many extended forms, with diacritics and different sets of letters.  It is used for all modern Western European languages, almost all Central European languages, as well as languages like Vietnamese and Zulu.
 
-Among the syllabic languages, we can include:
+##### Abjads
+In abjads, characters generally represent mostly only consonants, leaving the reader to infer the vowels.  Most writing systems of the ancient and modern Near East are abjads.
+* Arabic and the derivative Persian alphabet used for languages like Urdu
+* Aramaic and Hebrew
+They are generally written [right-to-left](https://developer.mozilla.org/en-US/docs/Web/CSS/direction).
 
-* The logo-syllabic languages like Chinese and Japanese (Kanji)—for these languages, characters represent both sound (syllable) and meaning, with words made up of one or more characters. Typically, there are multiple characters for each possible syllable, each with a different meaning.
-* Most languages from the Indian subcontinent, such as Bengali, Hindi (Devanagari), Malayalam, Punjabi, Tamil, Telugu, etc.;
-    * Burmese, Khmer, Lao.
-    * Thai—another particularity. In its written form, Thai does not use separators between words (like we do in English, with a space used as a word separator). Spaces in Thai are the equivalent of the period in English and mark the end of a sentence.
-    * Cree, Ethiopic, Inuktitut, Tibetan.
+##### Abugidas
+In abugidas or syllabaries, characters represent syllables.
+* the Ethiopic writing system Ge'ez, used for languages of the Horn of Africa like Amharic 
+* most writing systems for languages from the Indian subcontinent, such as Devanagari - used for Hindi and more - Bengali, Malayalam, Gurmukhi, Tamil, Telugu
+* Tibetan, Burmese, Khmer, Lao and Thai
+* Canadian syllabics used for indigenous languages like Inuktitut and Cree
+
+###### Logographics
+In logographics writing systems, characters represent both sounds - typically a syllable - and a meaning, with words made up of one or more characters.  Typically, there are multiple characters for each possible syllable, each with a different meaning.
+
+* Chinese, used for Mandarin and other Chinese languages, as well as in Japanese (Kanji)
+* ancient scripts like Egyptian, Akkadian, Urartian and Minoan
+
+###### Mixed
+Japanese uses a mix of Hiragana, Katakana and Kanji (Chinese), as well as the Latin alphabet.  Katakana is typically used for words borrowed in modern times.
+
+In practice, all modern languages include words and symbols in the Latin script in certain contexts, like URLs.  Languages like Chinese and Japanese have their own full-width versions of Latin alphabet characters and other Western symbols like numbers.
+
+Many languages, like Serbian, Mongolian, Uzbek, Uyghur, Punjabi are commonly written in multiple scripts.  A few sets of spoken languages, like Serbian and Croatian, Hindi and Urdu, and Persian and Tajik, are mutually intelligible but use different scripts.  A few, like Norwegian, have multiple orthographies with the same script.
 
 We will also mention here Bamum, a language spoken in parts of Cameroon, as an interesting case of a language that historically started using a syllabic script upon its creation in 1896, but later switched to an alphabetic script during the French colonial era. Today, efforts are made to revive the Bamum Syllabary despite the fact that many books, as well as the corresponding printing equipment, were destroyed a century ago.
 


### PR DESCRIPTION
A few goals with this PR

### Language vs writing system

Respect the distinction between a *language* and a *writing system* (script, alphabet...).  Currently there's confusion:
> Among the alphabetic **scripts**, we can include:
> [ lists languages ]
> Among the syllabic languages, we can include:

### Fix the breakdown of writing systems

Use a conventional breakdown.

Currently it makes a claim that is at odds with the consensus:
> Written languages can be classified in two main groups

For example, this is a more conventional breakdown:
<img width="423" alt="Screenshot 2021-12-14 at 17 20 44" src="https://user-images.githubusercontent.com/11457984/146017543-e73b63aa-5253-41a7-bfe1-b42947ec0b50.png">

### Consistency

The is overall message is clouded by tangential details on certain languages.  (Is the spread of the Latin alphabet to Africa really that different from how the Latin alphabet was spread to Ireland, or how the Cyrillic alphabet was spread to Tajikistan?  Is Thai actually the most important language that generally doesn't use spaces?)

